### PR TITLE
Feature/internet connectivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     
     <application
         android:allowBackup="true"

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/utils/NetworkUtils.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/utils/NetworkUtils.kt
@@ -1,0 +1,28 @@
+package jp.co.yumemi.android.code_check.utils
+
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import javax.inject.Inject
+
+/**
+ * Utility class for checking the availability of a network connection.
+ *
+ * @property connectivityManager An instance of [ConnectivityManager] injected by the constructor.
+ *                               It is used to query network capabilities and network state information.
+ */
+class NetworkUtils @Inject constructor(private val connectivityManager: ConnectivityManager) {
+
+    /**
+     * Determines whether there is an active network connection and if it is capable of
+     * accessing the Internet.
+     *
+     * This method uses [ConnectivityManager.getNetworkCapabilities] to query the active
+     * network for its capabilities and checks if it has the capability [NetworkCapabilities.NET_CAPABILITY_INTERNET].
+     *
+     * @return A [Boolean] indicating whether a network connection is available and is connected to the Internet.
+     */
+    fun isNetworkAvailable(): Boolean {
+        val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+        return capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+    }
+}


### PR DESCRIPTION
# Implement Network Connectivity Utility

This pull request introduces a set of changes aimed at improving how the app interacts with network connectivity checks. It centralizes the logic related to network checks into a single utility class and ensures that the necessary permission is requested.

## Changes
- Added the `ACCESS_NETWORK_STATE` permission to the `AndroidManifest.xml`. This is a preliminary step that grants the application the ability to access information about the network state which is essential for the `NetworkUtils` class.
- Created the `NetworkUtils` class. This class provides a method `isNetworkAvailable` that utilizes `ConnectivityManager` to check for active network connections and determine if the internet is accessible.

## Impact
- **Reliability**: By centralizing network checks in one class, we reduce the risk of misusing the `ConnectivityManager` and provide a single point of maintenance.
- **Efficiency**: The app now checks for network availability in a manner that's consistent with the latest Android practices, which is more efficient and robust against API changes.
- **Testability**: With the introduction of `NetworkUtils`, network-related functionality can be easily mocked in tests, leading to more reliable testing outcomes.

These changes lay the groundwork for any network-related operations that the app will perform and are a step forward in making the app more robust and maintainable.
