### PR TITLE
Feature/localization ja

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepoSearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/RepoSearchFragment.kt
@@ -151,7 +151,7 @@ class RepoSearchFragment : Fragment(R.layout.fragment_repo_search) {
                     (binding.recyclerView.adapter as? CustomAdapter)?.submitList(emptyList())
                     viewModel.search()
                 } else {
-                    Toast.makeText(requireContext(), "Please enter a search query", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), R.string.empty_query_error, Toast.LENGTH_SHORT).show()
                 }
                 true
             } else false

--- a/app/src/main/res/layout/fragment_repo_search.xml
+++ b/app/src/main/res/layout/fragment_repo_search.xml
@@ -30,7 +30,7 @@
                 android:textColor="@color/white"
                 android:textSize="25sp"
                 android:textStyle="bold"
-                android:text="Search GitHub" />
+                android:text="@string/search_github" />
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/searchInputText"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,27 @@
+<resources>
+    <string name="app_name">Android エンジニア コードチェック</string>
+    <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
+    <string name="written_language">%sで書かれています</string>
+    <string name="stars">%1$d スター</string>
+    <string name="watchers">%1$d ウォッチャー</string>
+    <string name="forks">%1$d フォーク</string>
+    <string name="open_issues">%1$d オープンイシュー</string>
+
+    <!-- BEGIN - Network Error Dialog Strings -->
+    <string name="network_error_title">インターネット接続なし</string>
+    <string name="network_error_message">インターネット接続を確認して、もう一度お試しください。</string>
+    <string name="open_settings">設定を開く</string>
+    <string name="dismiss">閉じる</string>
+    <!-- END - Network Error Dialog Strings -->
+
+    <!-- BEGIN - Repository Item UI Strings -->
+    <string name="item_additional_information">アイテムに関する詳細情報</string>
+    <string name="item_additional_info_title">情報</string>
+    <string name="default_repo_fork_count">78</string>
+    <string name="default_repo_view_count">87</string>
+    <string name="default_repo_star_count">88</string>
+    <string name="default_repo_item_title">JetBrains/kotlin</string>
+    <string name="repo_item_image_content_desc">リポジトリアイテムの画像</string>
+    <string name="search_github">ギットハブ を検索</string>
+    <!-- END - Repository Item UI Strings -->
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -23,5 +23,6 @@
     <string name="default_repo_item_title">JetBrains/kotlin</string>
     <string name="repo_item_image_content_desc">リポジトリアイテムの画像</string>
     <string name="search_github">ギットハブ を検索</string>
+    <string name="empty_query_error">検索クエリを入力してください</string>
     <!-- END - Repository Item UI Strings -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="default_repo_star_count">88</string>
     <string name="default_repo_item_title">JetBrains/kotlin</string>
     <string name="repo_item_image_content_desc">repo item image</string>
+    <string name="search_github">Search GitHub</string>
     <!-- END - Repository Item UI  Strings -->
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="default_repo_item_title">JetBrains/kotlin</string>
     <string name="repo_item_image_content_desc">repo item image</string>
     <string name="search_github">Search GitHub</string>
+    <string name="empty_query_error">Please enter a search query</string>
     <!-- END - Repository Item UI  Strings -->
 
 </resources>


### PR DESCRIPTION
# Add Japanese Translations

## Overview
This pull request adds Japanese translations for various strings in the application. It aims to enhance the user experience for Japanese-speaking users by providing local language support.

## Video Demonstration
A video demonstration of the changes can be found here: 
<video  src="https://github.com/Hasitha-Su/Android-CodeChck-Test/assets/37993553/dfb9039e-80fb-4c05-bee3-4ded23b7d428"></video>

## Changes
- Added Japanese translations for the following strings:
  - `app_name`: "Android Engineer CodeCheck"
  - `searchInputText_hint`: "GitHub のリポジトリを検索できるよー"
  - `written_language`: "%s で書かれています"
  - `stars`: "%1$d スター"
  - `watchers`: "%1$d ウォッチャー"
  - `forks`: "%1$d フォーク"
  - `open_issues`: "%1$d オープンイシュー"
  - `network_error_title`: "インターネット接続がありません"
  - `network_error_message`: "インターネット接続を確認して、再試行してください。"
  - `open_settings`: "設定を開く"
  - `dismiss`: "閉じる"
  - `item_additional_information`: "アイテムに関する詳細情報"
  - `item_additional_info_title`: "情報"
  - `default_repo_fork_count`: "78"
  - `default_repo_view_count`: "87"
  - `default_repo_star_count`: "88"
  - `default_repo_item_title`: "JetBrains/kotlin"
  - `repo_item_image_content_desc`: "リポジトリのアイテム画像"
  - `search_github`: "ギットハブ を検索"
  - `empty_query_error`: "検索クエリを入力してください"

## Impact
This localization effort makes the app more accessible and user-friendly for Japanese speakers. It also demonstrates our commitment to supporting a diverse user base.

## Testing
- Ensure all translations are accurate and contextually appropriate.
- Test the app with Japanese locale settings to confirm the correct display of Japanese strings.
